### PR TITLE
Delete DeserializingStream's copy constructor

### DIFF
--- a/casadi/core/serializing_stream.hpp
+++ b/casadi/core/serializing_stream.hpp
@@ -67,6 +67,7 @@ namespace casadi {
   public:
     /// Constructor
     DeserializingStream(std::istream &in_s);
+    DeserializingStream(const DeserializingStream&) = delete;
 
     //@{
     /** \brief Reconstruct an object from the input stream


### PR DESCRIPTION
Fix to avoid weird Visual Studio compiler errors with `UniversalNodeOwner`